### PR TITLE
Feature: OSX Supported Screen Capture Source + Encoding Builder 

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,61 +1,136 @@
 use anyhow::{anyhow, bail, Context, Result};
 use ffmpeg::ffi::AVCodecContext;
-use ffmpeg::{codec::Context as CodecContext, encoder::Video, Frame, Packet};
-use ffmpeg_next as ffmpeg;
+use ffmpeg::{
+    codec::Context as CodecContext, encoder::video::Encoder as VideoEncoderOpened,
+    encoder::video::Video as VideoEncoder, frame, Error, Packet,
+};
+use ffmpeg_next::{self as ffmpeg};
+use ffmpeg_sys_next::{av_buffer_ref, AVBufferRef, EAGAIN};
 use log::info;
 use std::{
     collections::HashMap,
     ffi::{c_void, CString},
 };
 
-pub struct Encoder {
-    encoder: Video,
-    dimensions: (u32, u32),
+use crate::source::Source;
+
+pub struct EncodedPacket(pub Packet, pub Instant);
+
+// Simple Type Wrapper to organise enc preset and name
+pub struct Codec(String);
+
+impl Default for Codec {
+    fn default() -> Self {
+        #[cfg(target_os = "macos")]
+        return Self("h264_videotoolbox".to_string());
+        #[cfg(target_os = "windows")]
+        return Self("h264_nvenc".to_string());
+    }
 }
 
-impl Encoder {
-    pub fn new<F>(
-        encoder: &str,
-        encoder_options: Option<HashMap<String, String>>,
-        setting_func: F,
-    ) -> Result<Self>
-    where
-        F: FnOnce(&mut ffmpeg::encoder::video::Video) -> Result<()>,
-    {
-        let codec = ffmpeg::encoder::find_by_name(encoder)
-            .ok_or_else(|| anyhow!("Missing encoder {}", encoder))?;
+impl Into<String> for Codec {
+    fn into(self) -> String {
+        self.0
+    }
+}
 
+impl Codec {
+    fn default_settings(&self) -> HashMap<String, String> {
+        match self.0.as_str() {
+            "h264_nvenc" => HashMap::from([
+                ("preset".into(), "p6".into()),
+                ("tune".into(), "ull".into()),
+            ]),
+            _ => HashMap::from([]),
+        }
+    }
+}
+
+pub fn encode(encoder: &mut VideoEncoderOpened, frame: &frame::Video) -> Result<Option<Packet>> {
+    encoder.send_frame(frame)?;
+
+    let mut packet = Packet::empty();
+    if encoder.receive_packet(&mut packet).is_ok() {
+        return Ok(Some(packet));
+    }
+
+    Ok(None)
+}
+
+pub struct EncoderBuilder {
+    codec: Codec,
+    hw_ctx: Option<*mut AVBufferRef>,
+    example_frame: frame::Video,
+    customise: Option<Box<dyn FnOnce(&mut VideoEncoder)>>,
+}
+
+impl EncoderBuilder {
+    pub fn new() -> Self {
+        Self {
+            codec: Codec::default(),
+            hw_ctx: None,
+            example_frame: frame::Video::empty(),
+            customise: None,
+        }
+    }
+
+    pub fn set_encoder(mut self, c: Codec) -> Self {
+        self.codec = c;
+        self
+    }
+
+    pub fn for_source<T: Source>(mut self, src: &mut T) -> Self {
+        src.next_frame(&mut self.example_frame).expect("");
+        if src.hw_support() {
+            unsafe { self.hw_ctx = Some((*self.example_frame.as_ptr()).hw_frames_ctx) }
+        }
+        self
+    }
+
+    pub fn customise(mut self, f: impl FnOnce(&mut VideoEncoder) + 'static) -> Self {
+        self.customise = Some(Box::new(f));
+        self
+    }
+
+    pub fn open(mut self) -> Result<VideoEncoderOpened> {
+        let settings = self.codec.default_settings();
+        let name: String = self.codec.into();
+
+        let codec = ffmpeg::encoder::find_by_name(name.as_str())
+            .ok_or_else(|| anyhow!("Missing encoder {}", name))?;
         let codec_context = CodecContext::new_with_codec(codec);
 
-        let mut encoder = codec_context.encoder().video()?;
+        let mut enc = codec_context.encoder().video()?;
+        // general encoder options
+        enc.set_width(self.example_frame.width());
+        enc.set_height(self.example_frame.height());
+        enc.set_aspect_ratio(self.example_frame.aspect_ratio());
+        // TODO: will this work?
+        enc.set_format(self.example_frame.format());
 
-        setting_func(&mut encoder)?;
+        // set options based on cli args
+        if let Some(f) = self.customise.take() {
+            (f)(&mut enc)
+        }
 
-        let dimensions = (encoder.width(), encoder.height());
-
-        if let Some(encoder_options) = encoder_options {
-            for (key, value) in encoder_options.iter() {
-                info!("Setting option {key} {value}");
-                unsafe { Self::set_option(encoder.as_mut_ptr(), &key, &value)? };
+        if let Some(buf) = self.hw_ctx {
+            unsafe {
+                let encoder = &mut *enc.as_mut_ptr();
+                encoder.hw_frames_ctx = av_buffer_ref(buf);
             }
         }
 
-        Ok(Encoder {
-            encoder: encoder.open()?,
-            dimensions,
-        })
-    }
-
-    pub fn encode(&mut self, frame: &Frame) -> Result<Option<Packet>> {
-        self.encoder.send_frame(frame)?;
-
-        let mut packet = Packet::empty();
-        if self.encoder.receive_packet(&mut packet).is_ok() {
-            return Ok(Some(packet));
+        // set any encoder specific options from defaults
+        // in future, we could merge cli args in as well
+        for (key, value) in settings.iter() {
+            info!("Setting option {key} {value}");
+            unsafe { Self::set_option(enc.as_mut_ptr(), key, value)? };
         }
 
-        Ok(None)
+        Ok(enc.open()?)
     }
+
+    // helpers
 
     unsafe fn set_option(context: *mut AVCodecContext, name: &str, val: &str) -> Result<()> {
         let name_c = CString::new(name).context("Error in CString")?;
@@ -70,9 +145,5 @@ impl Encoder {
             bail!("set_option failed: {retval}");
         }
         Ok(())
-    }
-
-    pub fn dimensions(&self) -> (u32, u32) {
-        return self.dimensions;
     }
 }

--- a/src/source/avfoundation.rs
+++ b/src/source/avfoundation.rs
@@ -1,0 +1,50 @@
+use super::Source;
+use crate::SourceConfig;
+
+use anyhow::{anyhow, Result};
+use ffmpeg_next::{
+    codec::Context,
+    decoder::Video as VideoDecoder,
+    device,
+    format::{self, context::Input},
+    frame, Dictionary, Error, Packet,
+};
+
+// TODO: Could generalise this to any device in future
+pub struct AFScreenCapturer {
+    device: Input,
+    decoder: VideoDecoder,
+}
+
+impl AFScreenCapturer {
+    pub fn new(config: &SourceConfig) -> Result<Self> {
+        let input = device::input::video()
+            .find(|d| d.name() == "avfoundation")
+            .ok_or(anyhow!("missing device"))?;
+
+        let framerate = format!("{}/1", config.framerate);
+        let mut opts = Dictionary::new();
+        //opts.set("pixel_format", "uyvy422");
+        opts.set("pixel_format", "nv12");
+        opts.set("framerate", &framerate);
+
+        let device_index = config.device.clone().unwrap_or("1".to_string());
+        let device = format::open_with(&device_index, &input, opts)?.input();
+
+        let dec_ctx = Context::from_parameters(device.stream(0).unwrap().parameters())?;
+        let decoder = dec_ctx.decoder().video()?;
+
+        Ok(Self { device, decoder })
+    }
+}
+impl Source for AFScreenCapturer {
+    fn next_frame(&mut self, out: &mut frame::Video) -> Result<(), Error> {
+        let mut p = Packet::empty();
+        // EAGAIN may be returned to caller or EOF
+        p.read(&mut self.device)?;
+        self.decoder.send_packet(&p)?;
+        // EAGAIN shouldn't happen here, no need to loop
+        self.decoder.receive_frame(out)?;
+        Ok(())
+    }
+}

--- a/src/source/dxdup.rs
+++ b/src/source/dxdup.rs
@@ -2,7 +2,7 @@ use super::Source;
 use anyhow::{anyhow, Result};
 use ffmpeg_next::{
     filter::{self, Graph},
-    frame,
+    frame, Error,
 };
 
 pub struct DisplayDuplicator {
@@ -25,10 +25,11 @@ impl DisplayDuplicator {
 }
 
 impl Source for DisplayDuplicator {
-    fn get_frame(&mut self) -> Result<frame::Video> {
-        let mut frame = frame::Video::empty();
-        self.graph.get("out").unwrap().sink().frame(&mut frame)?;
-
-        Ok(frame)
+    fn hw_support(&self) -> bool {
+        true
+    }
+    fn next_frame(&mut self, out: &mut frame::Video) -> std::result::Result<(), Error> {
+        self.graph.get("out").unwrap().sink().frame(out)?;
+        Ok(())
     }
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -1,9 +1,16 @@
-use anyhow::Result;
-use ffmpeg_next::frame::video::Video;
+use ffmpeg_next::frame;
 
-#[cfg(target_os = "windows")]
-pub mod dxdup;
+mod avfoundation;
+mod dxdup;
+
+pub use avfoundation::AFScreenCapturer;
+pub use dxdup::DisplayDuplicator;
+
+pub use ffmpeg_next::util::error::Error;
 
 pub trait Source {
-    fn get_frame(&mut self) -> Result<Video>;
+    fn next_frame(&mut self, out: &mut frame::Video) -> Result<(), Error>;
+    fn hw_support(&self) -> bool {
+        false
+    }
 }

--- a/src/whip.rs
+++ b/src/whip.rs
@@ -1,7 +1,8 @@
-use crate::client::{Client, WebrtcEvent};
-use crate::EncodedPacket;
+use crate::{
+    client::{Client, WebrtcEvent},
+    encoder::EncodedPacket,
+};
 use bytes::Bytes;
-use ffmpeg_next;
 use futures::executor;
 use std::{sync::mpsc, time::Instant};
 use str0m::media::Direction as RtcDirection;


### PR DESCRIPTION
This change is as small as I can make it, so I'll try and break it down 

### 1. CLI options to choose the source of screen capture source, device and frame rate. 
- I took most of the inspiration from:  [https://github.com/bitwhip/bitwhip/pull/4](url)
```
Usage: bitwhip stream [OPTIONS] <URL> [TOKEN]

Arguments:
  <URL>    The WHIP URL
  [TOKEN]  The WHIP bearer token

Options:
  -c <CAPTURE_METHOD>          Capture method [default: av-foundation] [possible values: av-foundation, dxgi]
  -f, --framerate <FRAMERATE>  Target frames per second for capture device [default: 60]
  -d, --device <DEVICE>        Device(s) to capture, source specific
  -v...                        Increase log verbosity, multiple occurrences (-vvv) further increase
  -h, --help
  ```

### 2. Add AVFoundation based screen capture 'source' 

### 3. Add Encoder Builder 
- the logic now needs to fork based on platform + source, I felt the builder pattern could help tame the complexity. 
- Example code:
```
let encoder = EncoderBuilder::new()
            .for_source(&mut source)
            .customise(move |encoder| {
                encoder.set_frame_rate(Some(frame_rate));
                encoder.set_time_base(frame_rate.invert());
                encoder.set_gop(120);
                encoder.set_max_b_frames(0);
            })
            .open()?;
```
- the `for_source` method sets options based on captured frame ( dimensions, formats etc )
- we keep a similar configuration closure as previous impl to set other fields. In future, these could all be exposed via cli args ( is my thinking)

### 4. Small Change to the `Source` trait
- we allow the frame to be passed as ref for better reuse
- `hw_support` allow source to dictate encoder builder logic around hw frames
```
pub trait Source {
    fn next_frame(&mut self, out: &mut frame::Video) -> Result<(), Error>;
    fn hw_support(&self) -> bool {
        false
    }
```