### PR TITLE
Bug: fix player texture upload stride mismatch

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -1,7 +1,11 @@
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 use sdl2::pixels::PixelFormatEnum;
+use sdl2::video::WindowBuilder;
+use sdl2::VideoSubsystem;
+use std::io::Write;
 use std::sync::mpsc;
+use tracing::error;
 
 pub fn render_video(rx: mpsc::Receiver<ffmpeg_next::frame::Video>) {
     match rx.recv() {
@@ -18,20 +22,13 @@ pub fn render_video(rx: mpsc::Receiver<ffmpeg_next::frame::Video>) {
             let mut event_pump = sdl_context.event_pump().unwrap();
             let texture_creator = canvas.texture_creator();
             let mut texture = texture_creator
-                .create_texture_streaming(PixelFormatEnum::IYUV, first_frame.width(), first_frame.height())
+                .create_texture_streaming(
+                    PixelFormatEnum::IYUV,
+                    first_frame.width(),
+                    first_frame.height(),
+                )
                 .map_err(|e| e.to_string())
                 .expect("No error");
-
-            let buffer_size: i32;
-            unsafe {
-                buffer_size = ffmpeg_sys_next::av_image_get_buffer_size(
-                    first_frame.format().into(),
-                    first_frame.width() as i32,
-                    first_frame.height() as i32,
-                    32,
-                );
-            };
-
 
             'running: loop {
                 for event in event_pump.poll_iter() {
@@ -45,32 +42,46 @@ pub fn render_video(rx: mpsc::Receiver<ffmpeg_next::frame::Video>) {
                     }
                 }
 
-                texture
-                    .with_lock(None, |buffer: &mut [u8], _pitch: usize| {
+                let res = texture
+                    .with_lock(None, |mut buffer: &mut [u8], _pitch: usize| {
                         match rx.try_recv() {
-                            Ok(frame) => {
-                                unsafe {
-                                    let frame_ptr = *frame.as_ptr();
-                                    ffmpeg_sys_next::av_image_copy_to_buffer(
-                                        buffer.as_mut_ptr(),
-                                        buffer_size,
-                                        frame_ptr.data.as_ptr() as *mut _,
-                                        frame_ptr.linesize.as_ptr() as *mut _,
-                                        frame.format().into(),
-                                        frame_ptr.width,
-                                        frame_ptr.height,
-                                        32,
-                                    );
+                            Ok(frame) => unsafe {
+                                let Some(desc) = frame.format().descriptor() else {
+                                    return false;
+                                };
+                                let frame_ptr = *frame.as_ptr();
+
+                                // Copy to buffer, trim padding
+                                for p in 0..frame.planes() {
+                                    frame
+                                        .data(p)
+                                        .chunks_exact(frame_ptr.linesize[p] as usize)
+                                        .for_each(|row| {
+                                            let scale = match p {
+                                                0 => 0,
+                                                _ => desc.log2_chroma_w(),
+                                            };
+                                            let (a, _) = row.split_at(
+                                                ((frame.width() + (1 << scale) - 1) >> scale as u32)
+                                                    as usize,
+                                            );
+                                            if let Err(e) = buffer.write(a) {
+                                                error!("Error writing frame to texture: {}", e)
+                                            }
+                                        });
                                 }
-                            }
-                            Err(_err) => {}
+                                true
+                            },
+                            Err(_err) => false,
                         }
                     })
-                .expect("texture copy");
+                    .expect("texture copy");
 
-                canvas.clear();
-                canvas.copy(&texture, None, None).expect("No error");
-                canvas.present();
+                if res {
+                    canvas.clear();
+                    canvas.copy(&texture, None, None).expect("No error");
+                    canvas.present();
+                }
             }
         }
         Err(_err) => {}


### PR DESCRIPTION
On certain display sizes, anytime the stride length included some padding, av_image_copy_to_buffer  would crash because it seems `create_texture_streaming` isn't including the padding in ITS buffer, so we write past the end.

My current solution is to manually implement the copy, trimming padding. It seems to work, but not a video expert, so definitely open to feedback here